### PR TITLE
Hotfix move t2 -> t3 micro  and AZ deny_list functionality

### DIFF
--- a/provisioner/roles/aws_check_setup/tasks/main.yml
+++ b/provisioner/roles/aws_check_setup/tasks/main.yml
@@ -40,8 +40,22 @@
     region: "{{ec2_region}}"
   register: az_names
 
+- name: Remove any AZs in the aws_az_deny_list when defined
+  set_fact:
+    availability_zones: >-
+      {{ az_names.availability_zones | json_query(__filter_query) }}
+  vars:
+    __filter_query: >-
+      [?!contains(`{{ (aws_az_deny_list | default([])) | to_json }}`, zone_name)]
+
+- name: Output AWS Availability Zones (AZs)
+  debug:
+    var: availability_zones
+    verbosity: 2
+
 - name: SET AZ ZONE TO FIRST AVAILABLE
-  set_fact: ec2_az={{az_names.availability_zones[0].zone_name}}
+  set_fact: 
+    ec2_az: "{{ availability_zones[0].zone_name }}"
 
 - name: grab information about AWS user
   aws_caller_info:

--- a/provisioner/roles/manage_ec2_instances/defaults/main/main.yml
+++ b/provisioner/roles/manage_ec2_instances/defaults/main/main.yml
@@ -78,7 +78,7 @@ ec2_info:
     username: ec2-user
   rhel8:
     owners: 309956199498
-    size: t2.micro
+    size: t3.micro
     os_type: linux
     disk_space: 10
     architecture: x86_64
@@ -86,7 +86,7 @@ ec2_info:
     username: ec2-user
   rhel7:
     owners: 309956199498
-    size: t2.micro
+    size: t3.micro
     os_type: linux
     disk_space: 10
     architecture: x86_64
@@ -145,7 +145,7 @@ ec2_info:
     architecture: x86_64
   attendance_host:
     owners: 309956199498
-    size: t2.micro
+    size: t3.micro
     os_type: linux
     disk_space: 10
     architecture: x86_64


### PR DESCRIPTION
##### SUMMARY
Upgraded workshops using t2.micro to t3.micro - cheaper, faster, and generally more available on AWS

Added deny_list logic to allow the **optional** avoidance of AWS AZs, for example currently `us-east-1e` does not provide t3.micro but can be used for any AZ filtering


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- provisioner

##### ADDITIONAL INFORMATION
Tested with rhel_90 and Security